### PR TITLE
Change bind ip to work in docker container

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ pub async fn health() -> Result<HttpResponse> {
 async fn main() -> std::io::Result<()> {
     println!("Starting Web server");
     HttpServer::new(|| App::new().service(health))
-        .bind("127.0.0.1:8080")?
+        .bind("0.0.0.0:8080")?
         .run()
         .await
 }


### PR DESCRIPTION
Hey! :)
I am a total newby when it comes to docker and actix but still this little change could save some time for future users of this repository. It turns out that you cannot connect to the server running in docker container unless it's bound to 0.0.0.0 (instead of 127.0.0.1).